### PR TITLE
Fix for the deprecated BINARY_SENSOR_SCHEMA warning 

### DIFF
--- a/components/midi_in/__init__.py
+++ b/components/midi_in/__init__.py
@@ -136,12 +136,12 @@ CONFIG_SCHEMA = cv.All(
                     ),
                 }
             ),
-            cv.Optional(CONF_CONNECTED): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+            cv.Optional(CONF_CONNECTED): binary_sensor.binary_sensor_schema(binary_sensor.BinarySensor).extend(
                 {
                     cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
                 }
             ),
-            cv.Optional(CONF_PLAYBACK): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
+            cv.Optional(CONF_PLAYBACK): binary_sensor.binary_sensor_schema(binary_sensor.BinarySensor).extend(
                 {
                     cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
                 }


### PR DESCRIPTION
I'm not very familiar with esphome internals, but I checked out the developer's blog post about this and examined a couple of other components in making this short fix.  It seems to work great on my devices.  